### PR TITLE
Add examples for hiding sensitive files on Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ optional arguments:
   -a            Get all files referenced in index
 ```
 
+## Hide Your Git Repositories!
+
+**On Apache**
+
+The following `LocationMatch` rule will deny access to any `.git` repository that happens to be servable by an Apache web-server. It also denies access to `.htaccess` and `.htpasswd` files as well as shows an example of denying access to environment configuration files popular in many frameworks. `.env` as a convention is just an example.
+
+```
+<LocationMatch ^.*/(\.ht.*|\.env.*|\.git)/.*$>
+    Order allow,deny
+    Allow from none
+    Deny from all
+</LocationMatch>
+```


### PR DESCRIPTION
This PR adds a section to the project's README on how users might go about securing their environment if a publically accessible `.git` repository is found. The wording isn't the best in the world and the rule itself needs further review for mistakes but we use a similar rule in our environment.

Please consider adding something to this effect to the project and I would be glad to do additional research to determine a similar rule for Nginx. This gives folks a low-cost remediation target after discovering a security risk such as this.

The tool's awesome! Love it.
